### PR TITLE
chore: pin dependencies, add lockfile and improve CI security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Security audit
+        run: npm audit --audit-level=high
+
       - name: Run Cypress (headless)
         uses: cypress-io/github-action@v7
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "chance": "^1.1.12"
+        "chance": "1.1.12"
       },
       "devDependencies": {
-        "cypress": "^14.3.0",
-        "dotenv": "^17.4.2"
+        "cypress": "14.3.0",
+        "dotenv": "17.4.2"
       }
     },
     "node_modules/@colors/colors": {
@@ -1399,9 +1399,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "chance": "^1.1.12"
+    "chance": "1.1.12"
   },
   "devDependencies": {
-    "cypress": "^14.3.0",
-    "dotenv": "^17.4.2"
+    "cypress": "14.3.0",
+    "dotenv": "17.4.2"
   }
 }


### PR DESCRIPTION
- Pinned all dependency versions removing ^ ranges in package.json
- Updated lodash 4.17.23 to 4.18.1 fixing high severity vulnerability
- Added npm audit step to CI pipeline blocking on high/critical issues