### PR TITLE
feat: add PIM module coverage with employee management tests

### DIFF
--- a/cypress/e2e/login.spec.cy.js
+++ b/cypress/e2e/login.spec.cy.js
@@ -1,11 +1,7 @@
 import userData from "../fixtures/userData.json"
 import LoginPage from "../pages/LoginPage"
 
-
-
 const loginPage = new LoginPage()
-
-
 
 describe('Login Page', () => {
 

--- a/cypress/e2e/pim.spec.cy.js
+++ b/cypress/e2e/pim.spec.cy.js
@@ -1,0 +1,113 @@
+import userData from "../fixtures/userData.json"
+import MenuPage from "../pages/MenuPage"
+import PimPage from "../pages/PimPage"
+import HeaderPage from "../pages/HeaderPage"
+import Chance from "chance"
+
+const menuPage = new MenuPage()
+const pimPage = new PimPage()
+const headerPage = new HeaderPage()
+const chance = new Chance()
+
+describe('Pim Test', () => {
+
+    beforeEach(() => {
+        cy.loginPage(Cypress.env('USERNAME'), Cypress.env('PASSWORD'))
+    })
+
+    it('should create, search and delete an employee', () => {
+        const firstName = chance.first()
+        const middleName = chance.word()
+        const lastName = chance.last()
+
+        cy.navigateToAddEmployee()
+        pimPage.fillEmployee(firstName, middleName, lastName)
+        pimPage.saveForm()
+
+        cy.get('@employeeId').then((employeeId) => {
+            menuPage.accessPim()
+            pimPage.checkPimPage()
+            pimPage.searchEmployeeByName(firstName)
+            pimPage.validateSearchResult(firstName)
+
+            menuPage.accessPim()
+            pimPage.checkPimPage()
+            pimPage.searchEmployeeById(employeeId)
+            pimPage.validateSearchResult(employeeId)
+            pimPage.deleteEmployee()
+        })
+    })
+
+    it('should create an employee with login and authenticate', () => {
+        const firstName = chance.first()
+        const middleName = chance.word()
+        const lastName = chance.last()
+        const username = 'User' + Date.now()
+
+        cy.navigateToAddEmployee()
+        pimPage.fillEmployee(firstName, middleName, lastName)
+        pimPage.fillLoginDetails(username, userData.newEmployee.password, userData.newEmployee.password)
+        pimPage.fillStatus('Enabled')
+        pimPage.saveForm()
+
+        headerPage.logout()
+        cy.loginPage(username, userData.newEmployee.password)
+    })
+
+    it('should display validation when first name is empty', () => {
+        const middleName = chance.word()
+        const lastName = chance.last()
+
+        cy.navigateToAddEmployee()
+        pimPage.fillEmployee(userData.newEmployee.firstNameEmpty, middleName, lastName)
+        pimPage.clickSave()
+        pimPage.checkEmptyField()
+    })
+
+    it('should display validation when last name is empty', () => {
+        const firstName = chance.first()
+        const middleName = chance.word()
+
+        cy.navigateToAddEmployee()
+        pimPage.fillEmployee(firstName, middleName, userData.newEmployee.lastNameEmpty)
+        pimPage.clickSave()
+        pimPage.checkEmptyField()
+    })
+
+    it('should display validation when username already exists', () => {
+        const firstName = chance.first()
+        const middleName = chance.word()
+        const lastName = chance.last()
+
+        cy.navigateToAddEmployee()
+        pimPage.fillEmployee(firstName, middleName, lastName)
+        pimPage.fillLoginDetails(userData.newEmployee.usernameRepeat, userData.newEmployee.password, userData.newEmployee.password)
+        pimPage.clickSave()
+        pimPage.checkRepeatField()
+    })
+
+    it('should display validation when username is empty', () => {
+        const firstName = chance.first()
+        const middleName = chance.word()
+        const lastName = chance.last()
+
+        cy.navigateToAddEmployee()
+        pimPage.fillEmployee(firstName, middleName, lastName)
+        pimPage.fillLoginDetails(userData.newEmployee.usernameEmpty, userData.newEmployee.password, userData.newEmployee.password)
+        pimPage.clickSave()
+        pimPage.checkEmptyField()
+    })
+
+    it('should display validation when password is empty', () => {
+        const firstName = chance.first()
+        const middleName = chance.word()
+        const lastName = chance.last()
+        const username = 'User' + Date.now()
+
+        cy.navigateToAddEmployee()
+        pimPage.fillEmployee(firstName, middleName, lastName)
+        pimPage.fillLoginDetails(username, userData.newEmployee.passwordEmpty, userData.newEmployee.passwordEmpty)
+        pimPage.clickSave()
+        pimPage.checkEmptyField()
+    })
+})

--- a/cypress/e2e/user.spec.cy.js
+++ b/cypress/e2e/user.spec.cy.js
@@ -1,14 +1,10 @@
 import userData from "../fixtures/userData.json"
-import LoginPage from "../pages/LoginPage"
-import DashboardPage from "../pages/DashboardPage"
 import MenuPage from "../pages/MenuPage"
 import MyInfoPage from "../pages/MyInfoPage"
 import Chance from "chance"
 
 const chance = new Chance() //Read the chanceJS documentation for random data possibilities
 const menuPage = new MenuPage()
-const loginPage = new LoginPage()
-const dashboardPage = new DashboardPage()
 const myInfoPage = new MyInfoPage()
 
 describe('User Test', () => {
@@ -21,6 +17,7 @@ describe('User Test', () => {
   it('should update profile information successfully', () => {
 
     menuPage.accessMyInfo()
+    myInfoPage.checkMyInfoPage()
     myInfoPage.fillPersonalDetails(chance.first(), userData.personalDetails.middleName, chance.last()) // --------> example of using chanceJS
     myInfoPage.fillEmployeeDetails(userData.employeeDetails.employeeId, userData.employeeDetails.otherId, userData.employeeDetails.driversLicenseNumber, userData.employeeDetails.licenseExpiryDate)
     myInfoPage.fillStatus(userData.statusDetails.nationality, userData.statusDetails.maritalStatus, userData.statusDetails.gender)

--- a/cypress/fixtures/userData.json
+++ b/cypress/fixtures/userData.json
@@ -24,5 +24,13 @@
     "nationality": "Brazilian",
     "maritalStatus": "Married",
     "gender": "Male"
+  },
+  "newEmployee": {
+    "password": "Admin@1234",
+    "usernameRepeat": "Admin",
+    "firstNameEmpty": "",
+    "lastNameEmpty": "",
+    "usernameEmpty": "",
+    "passwordEmpty": ""
   }
 }

--- a/cypress/pages/DashboardPage.js
+++ b/cypress/pages/DashboardPage.js
@@ -9,7 +9,8 @@ class DashboardPage {
 
     checkDashboardPage() {
         cy.location('pathname').should('equal', '/web/index.php/dashboard/index')
-        cy.get(this.selectorList().dashboardGrid).should('be.visible')
+        cy.get(this.selectorList().dashboardGrid)
+            .should('be.visible')
     }
 
     accessDashboardPage() {

--- a/cypress/pages/ForgotPasswordPage.js
+++ b/cypress/pages/ForgotPasswordPage.js
@@ -18,7 +18,9 @@ class ForgotPasswordPage {
 
     checkForgotPasswordPage() {
         cy.location('pathname').should('equal', '/web/index.php/auth/requestPasswordResetCode')
-        cy.get(this.selectorList().forgotPasswordTitle).should('be.visible')
+        cy.get(this.selectorList().forgotPasswordTitle)
+            .should('be.visible')
+            .and('contain', 'Reset Password')
     }
 
     submitResetPassword(username) {

--- a/cypress/pages/LoginPage.js
+++ b/cypress/pages/LoginPage.js
@@ -9,17 +9,19 @@ class LoginPage {
             loginTitle: ".orangehrm-login-title"
         }
 
-        return selectors 
+        return selectors
     }
 
-    
+
     accessLoginPage() {
         cy.visit('auth/login')
     }
 
     checkLoginPage() {
         cy.location('pathname').should('equal', '/web/index.php/auth/login')
-        cy.get(this.selectorList().loginTitle).should('be.visible')
+        cy.get(this.selectorList().loginTitle)
+            .should('be.visible')
+            .and('contain', 'Login')
     }
 
     loginWithAnyUser(username, password) {
@@ -43,6 +45,5 @@ class LoginPage {
             .should('be.visible')
             .and('contain', 'Required')
     }
-
 }
 export default LoginPage 

--- a/cypress/pages/MyInfoPage.js
+++ b/cypress/pages/MyInfoPage.js
@@ -7,11 +7,18 @@ class MyInfoPage {
             lastNameField: "[name='lastName']",
             genericGroup: ".oxd-input-group",
             dateCloseField: ".--close",
-            submitButton: "[type='submit']",
             successToast: ".oxd-toast",
-            toastClose: ".oxd-toast-close"
+            toastClose: ".oxd-toast-close",
+            personalTitle: ".orangehrm-main-title"
         }
         return selectors
+    }
+
+    checkMyInfoPage() {
+        cy.location('pathname').should('include', '/pim/viewPersonalDetails')
+        cy.get(this.selectorList().personalTitle)
+            .should('be.visible')
+            .and('contain', 'Personal Details')
     }
 
     getFieldByLabel(labelName) {

--- a/cypress/pages/PimPage.js
+++ b/cypress/pages/PimPage.js
@@ -1,0 +1,137 @@
+class PimPage {
+
+    selectorList() {
+        const selectors = {
+            pimTitle: ".oxd-table-filter-title",
+            addEmployeeTitle: ".orangehrm-main-title",
+            topbarNavItem: ".oxd-topbar-body-nav-tab-item",
+            firstNameField: "[name='firstName']",
+            middleNameField: "[name='middleName']",
+            lastNameField: "[name='lastName']",
+            createLoginToggle: ".oxd-switch-input",
+            genericGroup: ".oxd-input-group",
+            formActions: ".oxd-form-actions",
+            successToast: ".oxd-toast",
+            toastClose: ".oxd-toast-close",
+            deleteButton: "button:has(.bi-trash)",
+            confirmDeleteButton: ".oxd-button--label-danger",
+            resultsTable: ".oxd-table",
+            emptyFieldAlert: ".oxd-input-field-error-message",
+        }
+        return selectors
+    }
+
+    getFieldByLabel(labelName) {
+        return cy.contains(this.selectorList().genericGroup, labelName).find('input')
+    }
+
+    getRadioButtonByLabel(groupLabel, optionText) {
+        return cy.contains(this.selectorList().genericGroup, groupLabel).contains('label', optionText)
+    }
+
+    checkPimPage() {
+        cy.location('pathname').should('include', '/pim/viewEmployeeList')
+        cy.get(this.selectorList().pimTitle)
+            .should('be.visible')
+            .and('contain', 'Employee Information')
+    }
+
+    checkAddEmployeePage() {
+        cy.location('pathname').should('include', '/pim/addEmployee')
+        cy.get(this.selectorList().addEmployeeTitle)
+            .should('be.visible')
+            .and('contain', 'Add Employee')
+    }
+
+    navigateToAddEmployee() {
+        cy.contains(this.selectorList().topbarNavItem, 'Add Employee').click()
+    }
+
+
+
+    fillEmployee(firstName, middleName, lastName) {
+        cy.get(this.selectorList().firstNameField).should('not.be.disabled').clear()
+        cy.get(this.selectorList().middleNameField).should('not.be.disabled').clear()
+        cy.get(this.selectorList().lastNameField).should('not.be.disabled').clear()
+
+        if (firstName) cy.get(this.selectorList().firstNameField).type(firstName)
+        if (middleName) cy.get(this.selectorList().middleNameField).type(middleName)
+        if (lastName) cy.get(this.selectorList().lastNameField).type(lastName)
+        this.getFieldByLabel('Employee Id').invoke('val').as('employeeId')
+    }
+
+    fillStatus(status) {
+        this.getRadioButtonByLabel('Status', status).click()
+    }
+
+    fillLoginDetails(username, password, confirmPassword) {
+        cy.intercept('POST', '**/validation/password').as('passwordValidation')
+        cy.get(this.selectorList().createLoginToggle).click()
+        this.getFieldByLabel('Username').clear()
+        this.getFieldByLabel('Password').clear()
+        this.getFieldByLabel('Confirm Password').clear()
+
+        if (username) this.getFieldByLabel('Username').type(username)
+        if (password) this.getFieldByLabel('Password').type(password)
+        if (confirmPassword) this.getFieldByLabel('Confirm Password').type(confirmPassword)
+        if (password) cy.wait('@passwordValidation')
+    }
+
+    saveForm() {
+        cy.get(this.selectorList().formActions).contains('button', 'Save').click()
+        cy.get(this.selectorList().successToast).should('contain', 'Successfully Saved')
+        cy.get(this.selectorList().toastClose).click()
+    }
+
+    clickSave() {
+        cy.get(this.selectorList().formActions).contains('button', 'Save').click()
+    }
+
+    cancelForm() {
+        cy.get(this.selectorList().formActions).contains('button', 'Cancel').click()
+    }
+
+    searchEmployeeByName(firstName) {
+        cy.intercept('GET', '**/pim/employees**').as('searchResults')
+        this.getFieldByLabel('Employee Name').clear().type(firstName)
+        cy.contains('button', 'Search').click()
+        cy.wait('@searchResults')
+    }
+
+    searchEmployeeById(employeeId) {
+        cy.intercept('GET', '**/pim/employees**').as('searchResults')
+        this.getFieldByLabel('Employee Id').clear().type(employeeId)
+        cy.contains('button', 'Search').click()
+        cy.wait('@searchResults')
+    }
+
+    validateSearchResult(firstName, employeeId) {
+        if (firstName) cy.get(this.selectorList().resultsTable).should('contain', firstName)
+        if (employeeId) cy.get(this.selectorList().resultsTable).should('contain', employeeId)
+    }
+
+    deleteEmployee() {
+        // Ensures search returned exactly 1 result before deleting
+        cy.get(this.selectorList().resultsTable)
+            .find(this.selectorList().deleteButton)
+            .should('have.length', 1)
+            .click()
+        cy.get(this.selectorList().confirmDeleteButton).click()
+        cy.get(this.selectorList().successToast).should('contain', 'Successfully Deleted')
+        cy.get(this.selectorList().toastClose).click()
+    }
+
+    checkEmptyField() {
+        cy.get(this.selectorList().emptyFieldAlert)
+            .should('be.visible')
+            .and('contain', 'Required')
+    }
+
+    checkRepeatField() {
+        cy.get(this.selectorList().emptyFieldAlert)
+            .should('be.visible')
+            .and('contain', 'Username already exists')
+    }
+}
+
+export default PimPage

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,10 +1,14 @@
 import LoginPage from "../pages/LoginPage"
 import DashboardPage from "../pages/DashboardPage"
 import ForgotPasswordPage from "../pages/ForgotPasswordPage"
+import MenuPage from "../pages/MenuPage"
+import PimPage from "../pages/PimPage"
 
 const forgotPasswordPage = new ForgotPasswordPage()
 const loginPage = new LoginPage()
 const dashboardPage = new DashboardPage()
+const menuPage = new MenuPage()
+const pimPage = new PimPage()
 
 
 Cypress.Commands.add('loginPage', (username, password) => {
@@ -15,6 +19,12 @@ Cypress.Commands.add('loginPage', (username, password) => {
             loginPage.checkLoginPage()
             loginPage.loginWithAnyUser(username, password)
             dashboardPage.checkDashboardPage()
+        },
+        {
+            validate() {
+                dashboardPage.accessDashboardPage()
+                cy.location('pathname').should('include', 'dashboard')
+            }
         }
     )
     cy.visit('dashboard/index')
@@ -23,4 +33,11 @@ Cypress.Commands.add('loginPage', (username, password) => {
 Cypress.Commands.add('forgotPage', () => {
     forgotPasswordPage.accessForgotPasswordPage()
     forgotPasswordPage.checkForgotPasswordPage()
+})
+
+Cypress.Commands.add('navigateToAddEmployee', () => {
+    menuPage.accessPim()
+    pimPage.checkPimPage()
+    pimPage.navigateToAddEmployee()
+    pimPage.checkAddEmployeePage()
 })

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,19 +1,3 @@
-// ***********************************************************
-// This example support/e2e.js is processed and
-// loaded automatically before your test files.
-//
-// This is a great place to put global configuration and
-// behavior that modifies Cypress.
-//
-// You can change the location of this file or turn off
-// automatically serving support files with the
-// 'supportFile' configuration option.
-//
-// You can read more here:
-// https://on.cypress.io/configuration
-// ***********************************************************
-
-// Import commands.js using ES2015 syntax:
 import './commands'
 
 


### PR DESCRIPTION
- Add PimPage with full POM structure: selectors, helpers, fill methods, search, validate and delete
- Add 7 test scenarios covering create, search, delete, login creation and field validations
- Add cy.navigateToAddEmployee custom command for reusable navigation flow
- Add cy.session validate callback to handle session expiration between tests
- Add newEmployee fixture data to userData.json
- Improve check methods across LoginPage, ForgotPasswordPage and MyInfoPage to assert text content
- Remove unused imports and instances from user.spec.cy.js
- Remove boilerplate comments from e2e.js